### PR TITLE
Easier unit testing, gitignore the workdirs.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# Test output directories
+tests/workdir/*
+workdir/*
+
 # Prerequisites
 *.d
 

--- a/Makefile
+++ b/Makefile
@@ -11,11 +11,38 @@ build:
 	@ g++ src/*.cpp -o bin/$(NAME) \
 	$(STD) $(BOOST)
 
-build-test:
+## CLASS REDUCE
+build-reduce:
 	@ g++ src/Reduce.cpp \
 	tests/testReduce.cpp \
 	$(STD) $(BOOST) \
-	-o bin/test
+	-o bin/testReduce
+
+test-reduce: build-reduce
+	@echo "\n*** TESTING REDUCE CLASS ***"
+	@ ./bin/testReduce
+
+## CLASS MAP
+build-map:
+	@ g++ src/Map.cpp \
+	tests/testMap.cpp \
+	$(STD) $(BOOST) \
+	-o bin/testMap
+
+test-map: build-map
+	@echo "\n*** TESTING MAP CLASS ***"
+	@ ./bin/testMap
+
+## CLASS FILEMANAGER
+build-filmgr:
+	@ g++ src/FileManager.cpp \
+	tests/testFileManager.cpp \
+	$(STD) $(BOOST) \
+	-o bin/testFileManager
+
+test-filmgr: build-filmgr
+	@echo "\n*** TESTING FILE MANAGER CLASS ***"
+	@ ./bin/testFileManager
 
 build-debug:
 	@ g++ src/*.cpp -o bin/$(DEBUG_NAME) \
@@ -25,9 +52,8 @@ build-debug:
 run: build
 	@ ./bin/$(NAME) workdir/input workdir/output workdir/temp
 
-test: build build-test
-	@ ./bin/test
-	@ ./bin/$(NAME) tests/workdir/input tests/workdir/output tests/workdir/temp
+# run all unit tests
+test: test-map test-reduce test-filmgr
 
 debug: build-debug
 	@ gdb --args bin/$(DEBUG_NAME) tests/workdir/input tests/workdir/output tests/workdir/temp


### PR DESCRIPTION
I split up the unit tests per class so that they could be run collectively or individually. Also (since this seemed to be a problem in my instance), I added the workdir output to the root .gitignore file.